### PR TITLE
Preserve mask colors when resizing the image

### DIFF
--- a/apply_fisheye_distortion.py
+++ b/apply_fisheye_distortion.py
@@ -155,7 +155,13 @@ def _process_file(f_json: Path, f_img: Path, dir_output: Path, dist_coeff: np.nd
     dist_img = distort_image(img, cam_intr, dist_coeff, mode, crop_output=crop_resize_output, crop_type=crop_type)
     if crop_resize_output:
         h, w = img.shape[:2]
-        dist_img = cv2.resize(dist_img, (w, h), cv2.INTER_CUBIC)
+        if mode == DistortMode.NEAREST:
+            x_grid = np.linspace(0, dist_img.shape[0] - 1, h).astype(np.uint32)
+            y_grid = np.linspace(0, dist_img.shape[1] - 1, w).astype(np.uint32)
+            grid = tuple(np.meshgrid(x_grid, y_grid, indexing='ij'))
+            dist_img = dist_img[grid]
+        else:
+            dist_img = cv2.resize(dist_img, (w, h), cv2.INTER_CUBIC)
 
     # Save Result
     out_filename = dir_output / f"{f_img.stem}.dist{f_img.suffix}"


### PR DESCRIPTION
Alas, OpenCV lose colors even if we use nearest or area interpolation.
I just switched to getting colors by the grid.

Pros: it's a quick fix, cons: we may lose very small masks.

![image](https://user-images.githubusercontent.com/462138/142714267-7ed34f0f-aeb8-4fea-8dd0-f1eff1fbc6a5.png)
